### PR TITLE
feature(labmda): Respect event.isBase64Encoded flag

### DIFF
--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -39,6 +39,10 @@ export function graphqlLambda(
         statusCode: 500,
       });
     }
+    if (event.isBase64Encoded && event.body) {
+      const bodyBuffer = new Buffer(event.body, 'base64');
+      event.body = bodyBuffer.toString('ascii');
+    }
     runHttpQuery([event, context], {
       method: event.httpMethod,
       options: options,

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -41,7 +41,7 @@ export function graphqlLambda(
     }
     if (event.isBase64Encoded && event.body) {
       const bodyBuffer = new Buffer(event.body, 'base64');
-      event.body = bodyBuffer.toString('ascii');
+      event.body = bodyBuffer.toString('utf8');
     }
     runHttpQuery([event, context], {
       method: event.httpMethod,


### PR DESCRIPTION
[AWS Lambdas](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format) have the option for the body being sent to the Function to be encoded in Base64.  I'm trying to use this feature with Zeit's `now dev` and they are, indeed, Base64 encoding the body.  Funnily enough, this is not the case when you run your lambda function within their production environment.  Because of AWS having this flag, I thought it was appropriate to make a PR here rather than have Zeit change their practices.
